### PR TITLE
Allow view to be notified

### DIFF
--- a/src/Caliburn.Micro.Core/Screen.cs
+++ b/src/Caliburn.Micro.Core/Screen.cs
@@ -109,6 +109,7 @@ namespace Caliburn.Micro
             Log.Info("Activating {0}.", this);
             await OnActivateAsync(cancellationToken);
             IsActive = true;
+            await OnActivatedAsync(cancellationToken);
 
             await (Activated?.InvokeAllAsync(this, new ActivationEventArgs
             {
@@ -181,6 +182,15 @@ namespace Caliburn.Micro
         /// Called when activating.
         /// </summary>
         protected virtual Task OnActivateAsync(CancellationToken cancellationToken)
+        {
+            return Task.FromResult(true);
+        }
+
+
+        /// <summary>
+        /// Called when view has been activated.
+        /// </summary>
+        protected virtual Task OnActivatedAsync(CancellationToken cancellationToken)
         {
             return Task.FromResult(true);
         }


### PR DESCRIPTION
This is in relation to
https://github.com/Caliburn-Micro/Caliburn.Micro/issues/593. I agree with the issue but is a pretty big breaking change. This should allow the correct sequence of activation, activated callbacks.